### PR TITLE
List ordering

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -120,12 +120,8 @@ class App extends Component {
 
         switch (currentWindow) {
             case 1:
-                x = (this.state.user && this.state.user.admin) ?
-                        <EditContributionView selectedContribution={this.state.selectedContribution}
-                                             admin={true}
-                                             publishedList={this.state.publishedList}
-                                             windowSwap={this.windowSwap.bind(this)}/> :
-                        <EditContributionView selectedContribution={this.state.selectedContribution}
+                x = <EditContributionView selectedContribution={this.state.selectedContribution}
+                                             admin={this.state.user && this.state.user.admin}
                                              publishedList={this.state.publishedList}
                                              windowSwap={this.windowSwap.bind(this)}/>;
                                              break;

--- a/client/ContributionsListView.js
+++ b/client/ContributionsListView.js
@@ -58,6 +58,11 @@ class MainPageTB extends Component {
     handleAddButtonClick() {
         let contribName = window.prompt("Enter collection name:");
         if (contribName) {
+            let lst = this.props.contributions;
+            let maxIndex = 0;
+            lst.forEach( (e) => {
+                if(e.index > maxIndex) maxIndex = e.index;
+            })
             fb.base.addToCollection(`Contributions`, {
                 name: contribName,
                 description: '',
@@ -69,6 +74,7 @@ class MainPageTB extends Component {
                 bioUrl: '',
                 bioName: '',
                 bioThumbnail: '',
+                index: maxIndex + 1,
             });
         } else {
             window.alert("Collection name can not be blank!");
@@ -81,7 +87,13 @@ class MainPageTB extends Component {
 
     render() {
         const classes = this.props.classes;
-        const contrib = this.props.contributions;
+        let contrib = this.props.contributions;
+        contrib = contrib.filter(e => e.type);
+        contrib.sort((a, b) => {
+            if (!a.index) return 1;
+            if (!b.index) return -1;
+            return b.index - a.index;
+        });
 
         return (
             <div>
@@ -93,7 +105,7 @@ class MainPageTB extends Component {
                         <Button onClick={() => { return this.handleAddButtonClick.bind(this)() }} variant="outlined" color={"primary"} startIcon={<Add />}
                             className={classes.button}>Add Collection </Button>
                         <List className={classes.contributionList}>
-                            {contrib.filter(e => e.type).map((e) => {
+                            {contrib.map((e) => {
                                 let pendingApproval = e.approval === "pending";
                                 let published = this.props.publishedList && this.props.publishedList[e.ref.id] === 'true';
                                 return (

--- a/client/EditContributionView.js
+++ b/client/EditContributionView.js
@@ -259,6 +259,7 @@ class EditContributionView extends Component {
                 publishedText = "Published";
             }
         }
+        
         return (
             <div>
                 <div>
@@ -376,17 +377,11 @@ class EditContributionView extends Component {
                             label={publishedText}
                             labelPlacement="bottom"
                             control={
-                                this.props.admin ? 
                                     <Switch
-                                        name="publishedSwitch"
-                                        checked={(this.props.publishedList && contrib && (this.props.publishedList[contrib.ref.id] === 'true'))}
-                                        onChange={this.handleSwitchChange}
-                                        color="secondary"
-                                    /> :
-                                    <Switch
-                                        disabled
+                                        disabled={!this.props.admin}
                                         name="publishedSwitch"
                                         checked={(this.props.publishedList && contrib &&  (this.props.publishedList[contrib.ref.id] === 'true'))}
+                                        onChange={this.handleSwitchChange}
                                         color="secondary"
                                     /> 
                                 }

--- a/client/MediaUpload.js
+++ b/client/MediaUpload.js
@@ -127,7 +127,14 @@ class MediaUpload extends Component {
 
     render() {
         const classes = this.props.classes;
-        let fileUploads = this.state.collection.map((fileDoc) => {
+        let fileUploads = this.state.collection;
+        fileUploads.sort((a, b) => {
+            if (!a.index) return -1;
+            if (!b.index) return 1;
+            return a.index - b.index;
+        });
+        fileUploads = fileUploads.map((fileDoc) => {
+            console.log(fileDoc.index);
             return (
                 <FileUpload key={fileDoc.index || fileDoc.name || randomBytes(2)}
                             fileType={this.props.uploadName}

--- a/client/MediaUpload.js
+++ b/client/MediaUpload.js
@@ -134,7 +134,6 @@ class MediaUpload extends Component {
             return a.index - b.index;
         });
         fileUploads = fileUploads.map((fileDoc) => {
-            console.log(fileDoc.index);
             return (
                 <FileUpload key={fileDoc.index || fileDoc.name || randomBytes(2)}
                             fileType={this.props.uploadName}


### PR DESCRIPTION
Fixes #56 and #86 .

Contributions are now sorted from newest to oldest (a new contribution appears at the top of the list). Contributions without an index (if they happen to exist) retain their order from firebase below all indexed contributions, since they should be older anyway.

FileUploads work the same way, except they will sort from oldest to newest (a new file upload appears at the bottom of the list, closer to the add single upload button), and unindexed items appear above.