### PR TITLE
Template fixes

### DIFF
--- a/server/mockup/header-new.html
+++ b/server/mockup/header-new.html
@@ -1,10 +1,10 @@
 <header id="header" class="sticky-style-2">
   <div id="top-social">
     <ul>
-      <li><a href="http://www.facebook.com/jazzhistorydatabase" class="si-facebook"><span class="ts-icon"><i class="icon-facebook"></i></span><span class="ts-text">Facebook</span></a></li>
-      <li><a href="http://www.instagram.com/jazzhistorydatabase/" class="si-instagram"><span class="ts-icon"><i class="icon-instagram2"></i></span><span class="ts-text">Instagram</span></a></li>
+      <li><a href="#" class="si-facebook"><span class="ts-icon"><i class="icon-facebook"></i></span><span class="ts-text">Facebook</span></a></li>
+      <li><a href="#" class="si-instagram"><span class="ts-icon"><i class="icon-instagram2"></i></span><span class="ts-text">Instagram</span></a></li>
       <!-- <li><a href="http://twitter.com/_JHDB_" class="si-twitter"><span class="ts-icon"><i class="icon-twitter"></i></span><span class="ts-text">Twitter</span></a></li> -->
-      <li><a href="mailto:contact@jazzhistorydatabase.com" class="si-email3"><span class="ts-icon"><i class="icon-email3"></i></span><span class="ts-text">contact us</span></a></li>
+      <li><a href="#" class="si-email3"><span class="ts-icon"><i class="icon-email3"></i></span><span class="ts-text">contact us</span></a></li>
     </ul>
   </div>
   <!-- #top-social end -->
@@ -12,7 +12,7 @@
     
     <!-- Logo
 				============================================= -->
-    <div id="logo"> <a href="http://legacy.jazzhistorydatabase.com/index.php" class="standard-logo"><img src="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png" alt="Jazz History Database Logo"></a> <a href="http://legacy.jazzhistorydatabase.com/index.php" class="retina-logo" data-dark-logo="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png"><img src="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png" alt="Jazz History Database Logo"></a> </div>
+    <div id="logo"> <a href="#" class="standard-logo"><img src="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png" alt="Jazz History Database Logo"></a> <a href="http://legacy.jazzhistorydatabase.com/index.php" class="retina-logo" data-dark-logo="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png"><img src="http://legacy.jazzhistorydatabase.com/images/jhdb-logo.png" alt="Jazz History Database Logo"></a> </div>
     <!-- #logo end --> 
     
   </div>

--- a/server/mockup/header-new.html
+++ b/server/mockup/header-new.html
@@ -32,13 +32,13 @@
 			<li><a href="http://legacy.jazzhistorydatabase.com/musicians.php">
             <div>PERFORMANCES</div>
             </a></li>-->
-			<li><a href="http://legacy.jazzhistorydatabase.com/musicians.php">
+			<li><a href="#">
             <div>MUSICIANS</div>
             </a></li>
-          <li><a href="http://legacy.jazzhistorydatabase.com/events.php">
+          <li><a href="#">
             <div>EVENTS</div>
             </a></li>
-          <li><a href="http://legacy.jazzhistorydatabase.com/collections.php">
+          <li><a href="#">
             <div>COLLECTIONS</div>
             </a></li>
         </ul>
@@ -49,7 +49,7 @@
           <form action="search.php" method="get">
             <input type="text" name="zoom_query"  class="form-control" value="" placeholder="Type Search Text &amp; Hit Enter..">
           </form>
-        c</div>
+        </div>
         <!-- #top-search end --> 
         
       </div>

--- a/server/server.js
+++ b/server/server.js
@@ -142,6 +142,8 @@ let renderFromFirebase = (req, res, collRef) => {
 
                 collectionDoc.shortDescription = collectionDoc && collectionDoc.description && collectionDoc.description.substr(200);
 
+                collectionDoc.dataItems = (images.length < 6) ? images.length : 5;
+
                 collectionDoc.images = images;
                 collectionDoc.audio = audio;
                 collectionDoc.video = video;

--- a/server/server.js
+++ b/server/server.js
@@ -89,12 +89,21 @@ let renderFromFirebase = (req, res, collRef) => {
         imgSnapshot.forEach(doc => {
             images.push(doc.data());
         });
+        images.sort((a, b) => {
+            if (!a.index) return -1;
+            if (!b.index) return 1;
+            return a.index - b.index;
+        });
         let audio = [];
         collRef.ref.collection("Audio").get().then( audioSnapshot => {
             audioSnapshot.forEach(doc => {
                 audio.push(doc.data());
             });
-
+            audio.sort((a, b) => {
+                if (!a.index) return -1;
+                if (!b.index) return 1;
+                return a.index - b.index;
+            });
             let video = [];
             collRef.ref.collection("Video").get().then( videoSnapshot => {
                 videoSnapshot.forEach(doc => {
@@ -102,8 +111,34 @@ let renderFromFirebase = (req, res, collRef) => {
                     data.url = "https://www.youtube.com/embed/" + data.url.split("/")[3];
                     video.push(data);
                 });
-
+                video.sort((a, b) => {
+                    if (!a.index) return -1;
+                    if (!b.index) return 1;
+                    return a.index - b.index;
+                });
                 logger.log(`Rendering preview template with name: ${collRef.name} found doc id: ${collRef.ref.id}`);
+
+                collectionDoc.descriptionParagraphs = [];
+                let done = false;
+                let start = 0;
+                let length;
+                let nextParagraph;
+                while (!done) {
+                    nextParagraph = collectionDoc.description.indexOf('\n', start);
+                    if (nextParagraph === -1) {
+                        length = collectionDoc.description.length;
+                        done = true;
+                    } else if (start === collectionDoc.description.length) {
+                        length = collectionDoc.description.length;
+                        done = true;
+                    } else {
+                        length = nextParagraph - start;
+                    }
+                    collectionDoc.descriptionParagraphs.push({
+                        paragraph: collectionDoc.description.substr(start, length),
+                    });
+                    start = nextParagraph + 1;
+                }
 
                 collectionDoc.shortDescription = collectionDoc && collectionDoc.description && collectionDoc.description.substr(200);
 

--- a/server/views/layouts/template.handlebars
+++ b/server/views/layouts/template.handlebars
@@ -39,7 +39,7 @@
 
 </head>
 
-<body>
+<body class="">
 
 <!-- Document Wrapper
 ============================================= -->
@@ -90,6 +90,10 @@
             white-space: pre-wrap;
             word-wrap: break-word;
         }
+
+        #page-menu.sticky-page-menu #page-menu-wrap {
+            top: 60px;
+        }
     </style>
 
 
@@ -98,7 +102,7 @@
     <section id="content">
         <!-- Collection nav bar start-->
         <div id="page-menu">
-            <div style="background-color: #333333">
+            <div id="page-menu-wrap">
                 <div class="container clearfix">
                     <div class="menu-title" style="cursor:pointer;" onclick="goToByScroll('section-bio')"> {{name}} Collection </div>
                     <nav>
@@ -117,8 +121,7 @@
                             </li>
                         </ul>
                     </nav>
-                    <div id="page-submenu-trigger"><i class="icon-reorder"></i>
-                    </div>
+                    <div id="page-submenu-trigger"><i class="icon-reorder"></i></div>
                 </div>
             </div>
         </div>
@@ -166,13 +169,13 @@
                             <h2> Images</h2>
                         </div>
                         <!--Carousel-->
-                        <div id="oc-portfolio-sidebar" class="owl-carousel carousel-widget" data-items="5" data-margin="10" data-loop="true" data-nav="false" data-autoplay="5000">
+                        <div id="oc-portfolio-sidebar" class="owl-carousel carousel-widget" data-items="{{dataItems}}" data-margin="10" data-loop="true" data-nav="false" data-autoplay="5000">
                             {{#each images }}
                                 <div class="oc-item">
                                     <div class="iportfolio">
                                         <div class="portfolio-image">
-                                            <a class="resize" href="#">
-                                                <img src="{{url}}" alt="{{name}}" height="200px">
+                                            <a href="#">
+                                                <img src="{{url}}" alt="{{name}}">
                                             </a>
 
                                             <div class="portfolio-overlay">
@@ -228,8 +231,7 @@
                 </div>
             {{/if}}
         </div>
-    </div>
-</div>
+    </section>
 </div>
 
 <!-- Footer
@@ -239,8 +241,6 @@
 
 
 
-
-</div>
 <!-- #wrapper end -->
 
 <!-- Go To Top

--- a/server/views/layouts/template.handlebars
+++ b/server/views/layouts/template.handlebars
@@ -79,15 +79,23 @@
         li>a {
             cursor: pointer;
         }
+
+        p.caption {
+            height: 60px;
+            font-size: 18px;
+            display: table-cell;
+            vertical-align: middle;
+            white-space: -moz-pre-wrap;
+            white-space: -o-pre-wrap;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
     </style>
 
 
     <!-- Content
     ============================================= -->
     <section id="content">
-
-        <br>
-
         <!-- Collection nav bar start-->
         <div id="page-menu">
             <div style="background-color: #333333">
@@ -118,16 +126,21 @@
         <!-- Content Wrap starts -->
         <div class="content-wrap">
             <!-- Bio -->
-            <div class="container clearfix">
+            <div class="container clearfix" style="padding-left: 20px; padding-right: 20px;">
                 <div class="fancy-title title-bottom-border" id="bio">
                     <h2>Biography of {{ name }} </h2>
                 </div>
                 <!-- Insert bio -->
-                <div class="coll-main-bio">
-                    <div class="col_three_fifth bottommargin-sm">
-                        <p class="bio">
-                            {{ description }}
-                        </p>
+                <div class="row clearfix" style=" padding-top: 20px;">
+                    <div class="col-sm-12">
+                        {{#if bioUrl}}
+                            <img class="biophoto" style="padding-left: 20px; padding-bottom: 20px;" width="500" align="right" src={{ bioUrl }}>
+                        {{/if}}
+                        {{#each descriptionParagraphs}}
+                            <p class="bio" style="font-size: 1.6em;">
+                                {{ paragraph }}
+                            </p>
+                        {{/each}}
                         <!--<p>-->
                             <!--<button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#fullBio">-->
                                 <!--Read Full Biography-->
@@ -139,62 +152,83 @@
                         <!--</div>-->
                     </div>
 
-                    <div class="col_two_fifth bottommargin-sm col_last">
+                    {{!-- <div class="col-sm-5">
                         <img src={{ bioUrl }}>
-                    </div>
+                    </div> --}}
                 </div>
             </div>
 
             <!-- Images Section -->
-            <div class="row common-height clearfix" style="padding-bottom:8%;">
-                <div class="col-sm-5 col-padding">
-                    <div class="fancy-title title-bottom-border" id="images">
-                        <h2> Images</h2>
-                    </div>
-                    <!--Carousel-->
-                    <div id="oc-portfolio-sidebar" class="owl-carousel carousel-widget" data-items="1" data-margin="10" data-loop="true" data-nav="false" data-autoplay="5000">
-                        {{#each images }}
-                        <div class="oc-item">
-                            <div class="iportfolio">
-                                <div class="portfolio-image">
-                                    <a class="resize" href="#">
-                                        <img src="{{url}}" alt="{{name}}" height="200px">
-                                    </a>
+            <div class="row common-height clearfix">
+                {{#if images}}
+                    <div class="col-sm-12 col-padding">
+                        <div class="fancy-title title-bottom-border" id="images">
+                            <h2> Images</h2>
+                        </div>
+                        <!--Carousel-->
+                        <div id="oc-portfolio-sidebar" class="owl-carousel carousel-widget" data-items="5" data-margin="10" data-loop="true" data-nav="false" data-autoplay="5000">
+                            {{#each images }}
+                                <div class="oc-item">
+                                    <div class="iportfolio">
+                                        <div class="portfolio-image">
+                                            <a class="resize" href="#">
+                                                <img src="{{url}}" alt="{{name}}" height="200px">
+                                            </a>
 
-                                    <div class="portfolio-overlay">
-                                        <a href="{{url}}" class="center-icon" data-lightbox="image"><i class="icon-line-plus"></i></a>
+                                            <div class="portfolio-overlay">
+                                                <a href="{{url}}" class="center-icon" data-lightbox="image"><i class="icon-line-plus"></i></a>
+                                            </div>
+                                        </div>
+                                        <div class="portfolio-desc center nobottompadding">
+                                            <h3><a href="portfolio-single.html">{{caption}}</a></h3>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="portfolio-desc center nobottompadding">
-                                    <h3><a href="portfolio-single.html">{{caption}}</a></h3>
-                                </div>
-                            </div>
+                            {{/each}}
                         </div>
-                        {{/each}}
                     </div>
-                </div>
-
-                <div class="col-sm-7 col-padding">
-                    <div>
-                        <div class="fancy-title title-bottom-border">
-                            <h2 id="section-interviews">Audio</h2>
+                {{/if}}
+            </div>
+            <div class="row common-height clearfix">
+                {{#if audio}}
+                    <div class="col-sm-12 col-padding">
+                        <div>
+                            <div class="fancy-title title-bottom-border">
+                                <h2 id="section-interviews">Audio</h2>
+                            </div>
+                            {{#each audio}}
+                                <div class="row" style="padding-left: 20px; padding-top: 10px;">
+                                    <div class="col-sm-4" style="padding-right: 10px;">
+                                        <audio controls style="height: 60px; display: table-cell; vertical-align: middle;">
+                                            <source src={{url}} type="audio/mp3">
+                                            Your browser does not support the audio element.
+                                        </audio>
+                                    </div>
+                                    <div class="col-sm-8" style="word-wrap: break-word;">
+                                        <p class="caption">{{caption}}</p>
+                                    </div>
+                                </div>
+                            {{/each}}
                         </div>
-                        {{#each audio}}
-                            <h5>{{name}}</h5>
-                            <audio controls>
-                                <source src={{url}} type="audio/mp3">
-                                Your browser does not support the audio element.
-                            </audio>
-                        {{/each}}
+                    </div>
+                {{/if}}
+            </div>
+            {{#if video}}
+                <div class="row common-height clearfix">
+                    <div class="col-sm-12 col-padding">
+                        <div class="fancy-title title-bottom-border">
+                            <h2 id="section-interviews">Videos</h2>
+                        </div>
                         {{#each video}}
-                            <h5>{{name}}</h5>
                             <iframe frameborder="0" scrolling="no" marginheight="0" marginwidth="0"width="356" height="200" type="text/html" 
                             src={{url}}><div><small><a href="https://youtubeembedcode.com/pl/">youtubeembedcode.com/pl/</a></small></div><div><small><a href="https://add-link-exchange.com">https://add-link-exchange.com</a></small></div><div><small><a href="https://youtubeembedcode.com/nl/">youtubeembedcode nl</a></small></div><div><small><a href="https://add-link-exchange.com">https://add-link-exchange.com</a></small></div><div><small><a href="https://youtubeembedcode.com/en">youtubeembedcode.com/en/</a></small></div><div><small><a href="https://add-link-exchange.com">add-link-exchange.com</a></small></div><div><small><a href="https://youtubeembedcode.com/es/">youtubeembedcode es</a></small></div><div><small><a href="https://add-link-exchange.com">w://add-link-exchange.com</a></small></div></iframe>
+                            <p class="center" style="height: 60px; font-size: 18px; padding-top: 10px;">{{caption}}</p>
                         {{/each}}
                     </div>
                 </div>
-            </div>
+            {{/if}}
         </div>
+    </div>
 </div>
 </div>
 


### PR DESCRIPTION
Fixes #89 and #34 .

New layout is simpler, page is broken vertically into 4 sections: Bio, Images, Audio, Videos. If a section has no content, it is omitted (except for the bio). All headers and content start/end align throughout the page.
In the bio, the text will wrap around the bio photo. If there is no bio photo, the text takes up the width of the page. The text is also now significantly larger.
In the images section, the image carousel displays up to 5 images at once. If there are less than 5 images, they will expand until all images show and  they take up the width of the screen. They will still animate even when there are fewer than 5 images. Captions should be no longer than a few words.
In the audio section, audio entries are to the left and a reasonable amount of space is left for captions, encouraging short paragraphs.
In the video section, videos are stacked on top of one another and take up the width of the page, with captions underneath. Captions can be as long as desired.
The header now works as intended, save for a minor bug also present in the JHDB site. Links to other parts of the site have been disabled in the header.

The templates are still no different for the preview/publish routes.